### PR TITLE
fix: :bug: Added logger to the kernel's Chicory module

### DIFF
--- a/src/main/java/org/extism/chicory/sdk/Kernel.java
+++ b/src/main/java/org/extism/chicory/sdk/Kernel.java
@@ -2,6 +2,8 @@ package org.extism.chicory.sdk;
 
 import static com.dylibso.chicory.wasm.types.Value.*;
 
+import com.dylibso.chicory.log.Logger;
+import com.dylibso.chicory.log.SystemLogger;
 import com.dylibso.chicory.runtime.ExportFunction;
 import com.dylibso.chicory.runtime.HostFunction;
 import com.dylibso.chicory.runtime.Instance;
@@ -36,8 +38,12 @@ public class Kernel {
     private final ExportFunction memoryBytes;
 
     public Kernel() {
+        this(new SystemLogger());
+    }
+
+    public Kernel(Logger logger) {
         var kernelStream = getClass().getClassLoader().getResourceAsStream("extism-runtime.wasm");
-        Instance kernel = Module.builder(kernelStream).build().instantiate();
+        Instance kernel = Module.builder(kernelStream).withLogger(logger).build().instantiate();
         memory = kernel.memory();
         alloc = kernel.export("alloc");
         free = kernel.export("free");

--- a/src/main/java/org/extism/chicory/sdk/Plugin.java
+++ b/src/main/java/org/extism/chicory/sdk/Plugin.java
@@ -24,12 +24,12 @@ public class Plugin {
     }
 
     public Plugin(Manifest manifest, HostFunction[] hostFunctions, Logger logger) {
-        this.kernel = new Kernel();
-        this.manifest = manifest;
-
         if (logger == null) {
             logger = new SystemLogger();
         }
+
+        this.kernel = new Kernel(logger);
+        this.manifest = manifest;
 
         // TODO: Expand WASI Support here
         var options = WasiOptions.builder().build();


### PR DESCRIPTION
This fixes the error on Android "java.lang.NoSuchMethodError: No static method getLogger(Ljava/lang/String)".
The error was generated from Kernel class, which was using the default System logger.