### PR TITLE
Add ExtismException as a RuntimeException subtype.

### DIFF
--- a/src/main/java/org/extism/chicory/sdk/ExtismException.java
+++ b/src/main/java/org/extism/chicory/sdk/ExtismException.java
@@ -1,0 +1,12 @@
+package org.extism.chicory.sdk;
+
+public class ExtismException extends RuntimeException{
+
+    public ExtismException(String message) {
+        super(message);
+    }
+
+    public ExtismException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/extism/chicory/sdk/Plugin.java
+++ b/src/main/java/org/extism/chicory/sdk/Plugin.java
@@ -55,16 +55,16 @@ public class Plugin {
                 var wasmInputStream = url.openStream();
                 builder = Module.builder(wasmInputStream);
             } catch (MalformedURLException e) {
-                throw new RuntimeException(e);
+                throw new ExtismException(e);
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new ExtismException(e);
             }
         } else if (wasm instanceof ManifestWasmFile) {
             builder = Module.builder(((ManifestWasmFile) wasm).filePath);
         } else if (wasm instanceof ManifestWasmBytes) {
             builder = Module.builder(((ManifestWasmBytes) wasm).bytes);
         } else {
-            throw new RuntimeException("We don't know what to do with this manifest");
+            throw new ExtismException("We don't know what to do with this manifest");
         }
 
         var moduleBuilder = builder.withLogger(logger).withHostImports(imports);
@@ -82,7 +82,7 @@ public class Plugin {
         if (result == 0) {
             return kernel.getOutput();
         } else {
-            throw new RuntimeException("Failed");
+            throw new ExtismException("Failed");
         }
     }
 


### PR DESCRIPTION
Minor change. Introduce a specific type of RuntimeException. It is backward-compatible with the previous behavior, but allows clients to distinguish between types of failure.

(Originally used in my experiment https://github.com/evacchi/quarkus-wasm-extension)