### PR TITLE
Plugin, Manifest builder APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ to complete a full Extism SDK. If anyone would like to work on it feel free to r
 ## Example
 
 ```java
-var manifest = Manifest.fromUrl("https://github.com/extism/plugins/releases/download/v1.0.0/greet.wasm");
-var plugin = new Plugin(manifest);
+var manifest =
+        Manifest.Builder
+                .fromUrl("https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
+                .build();
+var plugin = Plugin.Builder.ofManifest(manifest).build();
 var input = "Benjamin";
 var result = new String(plugin.call("greet", input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
 assertEquals("Hello, Benjamin!", result);

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ to complete a full Extism SDK. If anyone would like to work on it feel free to r
 ## Example
 
 ```java
-var manifest =
-        Manifest.Builder
-                .fromUrl("https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
-                .build();
+        var manifest =
+        Manifest.ofWasms(
+                ManifestWasm.fromUrl(
+                                "https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
+                        .build()).build();
 var plugin = Plugin.Builder.ofManifest(manifest).build();
 var input = "Benjamin";
 var result = new String(plugin.call("greet", input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);

--- a/src/main/java/org/extism/chicory/sdk/Manifest.java
+++ b/src/main/java/org/extism/chicory/sdk/Manifest.java
@@ -1,12 +1,19 @@
 package org.extism.chicory.sdk;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
 
 class ManifestWasm {
 }
 
 class ManifestWasmBytes extends ManifestWasm {
     final byte[] bytes;
+
     public ManifestWasmBytes(byte[] bytes) {
         this.bytes = bytes;
     }
@@ -34,32 +41,85 @@ class ManifestWasmUrl extends ManifestWasm {
     public ManifestWasmUrl(String url) {
         this.url = url;
     }
+
+    public InputStream getUrlAsStream() {
+        try {
+            var url = new URL(this.url);
+            return url.openStream();
+        } catch (MalformedURLException e) {
+            throw new ExtismException(e);
+        } catch (IOException e) {
+            throw new ExtismException(e);
+        }
+
+    }
 }
 
 public class Manifest {
+
+    public enum Validation {
+        Import, Type, All;
+    }
+
+    public static class Options {
+        boolean aot;
+        EnumSet<Validation> validationFlags = EnumSet.noneOf(Validation.class);
+
+        public Options withAoT() {
+            this.aot = true;
+            return this;
+        }
+
+        public Options withValidation(Validation... vs) {
+            this.validationFlags.addAll(List.of(vs));
+            return this;
+        }
+    }
+
+    public static class Builder {
+        final ManifestWasm[] wasms;
+        private Options options;
+
+        private Builder(ManifestWasm[] manifestWasms) {
+            this.wasms = manifestWasms;
+        }
+
+        public static Builder fromPath(String path) {
+            var wasm = new ManifestWasmPath(path);
+            return new Builder(new ManifestWasm[]{wasm});
+        }
+
+        public static Builder fromUrl(String url) {
+            var wasm = new ManifestWasmUrl(url);
+            return new Builder(new ManifestWasm[]{wasm});
+        }
+
+        public static Builder fromFilePath(Path path) {
+            var wasm = new ManifestWasmFile(path);
+            return new Builder(new ManifestWasm[]{wasm});
+        }
+
+        public static Builder fromBytes(byte[] bytes) {
+            var wasm = new ManifestWasmBytes(bytes);
+            return new Builder(new ManifestWasm[]{wasm});
+        }
+
+        public Builder withOptions(Options opts) {
+            this.options = opts;
+            return this;
+        }
+
+        public Manifest build() {
+            return new Manifest(wasms, options);
+        }
+
+    }
+
     final ManifestWasm[] wasms;
+    final Manifest.Options options;
 
-    public static Manifest fromPath(String path) {
-        var wasm = new ManifestWasmPath(path);
-        return new Manifest(new ManifestWasm[]{wasm});
-    }
-
-    public static Manifest fromUrl(String url) {
-        var wasm = new ManifestWasmUrl(url);
-        return new Manifest(new ManifestWasm[]{wasm});
-    }
-
-    public static Manifest fromFilePath(Path path) {
-        var wasm = new ManifestWasmFile(path);
-        return new Manifest(new ManifestWasm[]{wasm});
-    }
-
-    public static Manifest fromBytes(byte[] bytes) {
-        var wasm = new ManifestWasmBytes(bytes);
-        return new Manifest(new ManifestWasm[]{wasm});
-    }
-
-    Manifest(ManifestWasm[] wasms) {
+    Manifest(ManifestWasm[] wasms, Manifest.Options opts) {
         this.wasms = wasms;
+        this.options = opts;
     }
 }

--- a/src/main/java/org/extism/chicory/sdk/Manifest.java
+++ b/src/main/java/org/extism/chicory/sdk/Manifest.java
@@ -1,59 +1,7 @@
 package org.extism.chicory.sdk;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
-
-class ManifestWasm {
-}
-
-class ManifestWasmBytes extends ManifestWasm {
-    final byte[] bytes;
-
-    public ManifestWasmBytes(byte[] bytes) {
-        this.bytes = bytes;
-    }
-}
-
-class ManifestWasmFile extends ManifestWasm {
-    final Path filePath;
-
-    public ManifestWasmFile(Path path) {
-        this.filePath = path;
-    }
-}
-
-class ManifestWasmPath extends ManifestWasm {
-    final String path;
-
-    public ManifestWasmPath(String path) {
-        this.path = path;
-    }
-}
-
-class ManifestWasmUrl extends ManifestWasm {
-    final String url;
-
-    public ManifestWasmUrl(String url) {
-        this.url = url;
-    }
-
-    public InputStream getUrlAsStream() {
-        try {
-            var url = new URL(this.url);
-            return url.openStream();
-        } catch (MalformedURLException e) {
-            throw new ExtismException(e);
-        } catch (IOException e) {
-            throw new ExtismException(e);
-        }
-
-    }
-}
 
 public class Manifest {
 
@@ -76,32 +24,18 @@ public class Manifest {
         }
     }
 
+
+    public static Builder ofWasms(ManifestWasm... wasms) {
+        return new Builder(wasms);
+    }
+
     public static class Builder {
         final ManifestWasm[] wasms;
         private Options options;
+        private String name;
 
         private Builder(ManifestWasm[] manifestWasms) {
             this.wasms = manifestWasms;
-        }
-
-        public static Builder fromPath(String path) {
-            var wasm = new ManifestWasmPath(path);
-            return new Builder(new ManifestWasm[]{wasm});
-        }
-
-        public static Builder fromUrl(String url) {
-            var wasm = new ManifestWasmUrl(url);
-            return new Builder(new ManifestWasm[]{wasm});
-        }
-
-        public static Builder fromFilePath(Path path) {
-            var wasm = new ManifestWasmFile(path);
-            return new Builder(new ManifestWasm[]{wasm});
-        }
-
-        public static Builder fromBytes(byte[] bytes) {
-            var wasm = new ManifestWasmBytes(bytes);
-            return new Builder(new ManifestWasm[]{wasm});
         }
 
         public Builder withOptions(Options opts) {
@@ -110,7 +44,7 @@ public class Manifest {
         }
 
         public Manifest build() {
-            return new Manifest(wasms, options);
+            return new Manifest(wasms, name, options);
         }
 
     }
@@ -118,7 +52,7 @@ public class Manifest {
     final ManifestWasm[] wasms;
     final Manifest.Options options;
 
-    Manifest(ManifestWasm[] wasms, Manifest.Options opts) {
+    Manifest(ManifestWasm[] wasms, String name, Manifest.Options opts) {
         this.wasms = wasms;
         this.options = opts;
     }

--- a/src/main/java/org/extism/chicory/sdk/ManifestModuleMapper.java
+++ b/src/main/java/org/extism/chicory/sdk/ManifestModuleMapper.java
@@ -1,0 +1,53 @@
+package org.extism.chicory.sdk;
+
+import com.dylibso.chicory.aot.AotMachine;
+import com.dylibso.chicory.runtime.Module;
+
+class ManifestModuleMapper {
+    private final Manifest manifest;
+
+    ManifestModuleMapper(Manifest manifest) {
+        this.manifest = manifest;
+    }
+
+    Module.Builder toModuleBuilder() {
+        if (manifest.wasms.length > 1) {
+            throw new UnsupportedOperationException(
+                    "Manifests of multiple wasm files are not supported yet!");
+        }
+        Module.Builder mb = wasmToModuleBuilder(manifest.wasms[0]);
+        return withOptions(mb, manifest.options);
+    }
+
+    private Module.Builder wasmToModuleBuilder(ManifestWasm m) {
+        if (m instanceof ManifestWasmBytes) {
+            ManifestWasmBytes mwb = (ManifestWasmBytes) m;
+            return Module.builder(mwb.bytes);
+        } else if (m instanceof ManifestWasmPath) {
+            ManifestWasmPath mwp = (ManifestWasmPath) m;
+            return Module.builder(mwp.path);
+        } else if (m instanceof ManifestWasmFile) {
+            ManifestWasmFile mwf = (ManifestWasmFile) m;
+            return Module.builder(mwf.filePath);
+        } else if (m instanceof ManifestWasmUrl) {
+            ManifestWasmUrl mwu = (ManifestWasmUrl) m;
+            return Module.builder(mwu.getUrlAsStream());
+        } else {
+            throw new IllegalArgumentException("Unknown ManifestWasm type " + m.getClass());
+        }
+    }
+
+    private Module.Builder withOptions(Module.Builder mb, Manifest.Options opts) {
+        if (opts == null) {
+            return mb;
+        }
+        if (opts.aot) {
+            mb.withMachineFactory(AotMachine::new);
+        }
+        if (!opts.validationFlags.isEmpty()) {
+            throw new UnsupportedOperationException("Validation flags are not supported yet");
+        }
+        return mb;
+    }
+
+}

--- a/src/main/java/org/extism/chicory/sdk/ManifestWasm.java
+++ b/src/main/java/org/extism/chicory/sdk/ManifestWasm.java
@@ -1,0 +1,96 @@
+package org.extism.chicory.sdk;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+
+public abstract class ManifestWasm {
+
+    public static Builder fromPath(String path) {
+        var wasm = new ManifestWasmPath(path);
+        return new Builder(wasm);
+    }
+
+    public static Builder fromUrl(String url) {
+        var wasm = new ManifestWasmUrl(url);
+        return new Builder(wasm);
+    }
+
+    public static Builder fromFilePath(Path path) {
+        var wasm = new ManifestWasmFile(path);
+        return new Builder(wasm);
+    }
+
+    public static Builder fromBytes(byte[] bytes) {
+        var wasm = new ManifestWasmBytes(bytes);
+        return new Builder(wasm);
+    }
+
+    public static class Builder {
+        private final ManifestWasm wasm;
+
+        public Builder(ManifestWasm wasm) {
+            this.wasm = wasm;
+        }
+
+        public Builder withName(String name) {
+            this.wasm.name = name;
+            return this;
+        }
+
+        public ManifestWasm build() {
+            return this.wasm;
+        }
+
+    }
+
+    String name;
+
+}
+
+class ManifestWasmBytes extends ManifestWasm {
+    final byte[] bytes;
+
+    public ManifestWasmBytes(byte[] bytes) {
+        this.bytes = bytes;
+    }
+}
+
+class ManifestWasmFile extends ManifestWasm {
+    final Path filePath;
+
+    public ManifestWasmFile(Path path) {
+        this.filePath = path;
+    }
+}
+
+class ManifestWasmPath extends ManifestWasm {
+    final String path;
+
+    public ManifestWasmPath(String path) {
+        this.path = path;
+    }
+}
+
+class ManifestWasmUrl extends ManifestWasm {
+    final String url;
+
+    public ManifestWasmUrl(String url) {
+        this.url = url;
+    }
+
+    public InputStream getUrlAsStream() {
+        try {
+            var url = new URL(this.url);
+            return url.openStream();
+        } catch (MalformedURLException e) {
+            throw new ExtismException(e);
+        } catch (IOException e) {
+            throw new ExtismException(e);
+        }
+
+    }
+}

--- a/src/main/java/org/extism/chicory/sdk/Plugin.java
+++ b/src/main/java/org/extism/chicory/sdk/Plugin.java
@@ -9,10 +9,11 @@ import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
 
 public class Plugin {
+    public static Builder ofManifest(Manifest manifest) {
+        return new Builder(manifest);
+    }
+
     public static class Builder {
-        public static Builder ofManifest(Manifest manifest) {
-            return new Builder(manifest);
-        }
 
         private final Manifest manifest;
         private HostFunction[] hostFunctions = new HostFunction[0];

--- a/src/main/java/org/extism/chicory/sdk/Plugin.java
+++ b/src/main/java/org/extism/chicory/sdk/Plugin.java
@@ -10,6 +10,10 @@ import com.dylibso.chicory.wasi.WasiPreview1;
 
 public class Plugin {
     public static class Builder {
+        public static Builder ofManifest(Manifest manifest) {
+            return new Builder(manifest);
+        }
+
         private final Manifest manifest;
         private HostFunction[] hostFunctions = new HostFunction[0];
         private Logger logger;
@@ -31,10 +35,6 @@ public class Plugin {
         public Plugin build() {
             return new Plugin(manifest, hostFunctions, logger);
         }
-    }
-
-    public static Builder ofManifest(Manifest manifest) {
-        return new Builder(manifest);
     }
 
     private final Manifest manifest;

--- a/src/test/java/org/extism/chicory/sdk/PluginTest.java
+++ b/src/test/java/org/extism/chicory/sdk/PluginTest.java
@@ -5,15 +5,29 @@ import junit.framework.TestCase;
 import java.nio.charset.StandardCharsets;
 
 public class PluginTest
-    extends TestCase
-{
+    extends TestCase {
 
-    public void testGreet()
-    {
-        var manifest = Manifest.fromUrl("https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm");
-        var plugin = new Plugin(manifest);
+    public void testGreet() {
+        var manifest =
+                Manifest.Builder
+                        .fromUrl("https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
+                        .build();
+        var plugin = Plugin.ofManifest(manifest).build();
         var input = "Benjamin";
         var result = new String(plugin.call("greet", input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         assertEquals("Hello, Benjamin!", result);
     }
+
+    public void testGreetAoT() {
+        var manifest =
+                Manifest.Builder
+                        .fromUrl("https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
+                        .withOptions(new Manifest.Options().withAoT())
+                        .build();
+        var plugin = Plugin.ofManifest(manifest).build();
+        var input = "Benjamin";
+        var result = new String(plugin.call("greet", input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        assertEquals("Hello, Benjamin!", result);
+    }
+
 }

--- a/src/test/java/org/extism/chicory/sdk/PluginTest.java
+++ b/src/test/java/org/extism/chicory/sdk/PluginTest.java
@@ -8,10 +8,11 @@ public class PluginTest extends TestCase {
 
     public void testGreet() {
         var manifest =
-                Manifest.Builder
-                        .fromUrl("https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
-                        .build();
-        var plugin = Plugin.Builder.ofManifest(manifest).build();
+                Manifest.ofWasms(
+                        ManifestWasm.fromUrl(
+                                "https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
+                        .build()).build();
+        var plugin = Plugin.ofManifest(manifest).build();
         var input = "Benjamin";
         var result = new String(plugin.call("greet", input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         assertEquals("Hello, Benjamin!", result);
@@ -19,11 +20,14 @@ public class PluginTest extends TestCase {
 
     public void testGreetAoT() {
         var manifest =
-                Manifest.Builder
-                        .fromUrl("https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
+                Manifest.ofWasms(
+                        ManifestWasm.fromUrl(
+                                "https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
+                                .withName("greet")
+                                .build())
                         .withOptions(new Manifest.Options().withAoT())
                         .build();
-        var plugin = Plugin.Builder.ofManifest(manifest).build();
+        var plugin = Plugin.ofManifest(manifest).build();
         var input = "Benjamin";
         var result = new String(plugin.call("greet", input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         assertEquals("Hello, Benjamin!", result);

--- a/src/test/java/org/extism/chicory/sdk/PluginTest.java
+++ b/src/test/java/org/extism/chicory/sdk/PluginTest.java
@@ -4,15 +4,14 @@ import junit.framework.TestCase;
 
 import java.nio.charset.StandardCharsets;
 
-public class PluginTest
-    extends TestCase {
+public class PluginTest extends TestCase {
 
     public void testGreet() {
         var manifest =
                 Manifest.Builder
                         .fromUrl("https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
                         .build();
-        var plugin = Plugin.ofManifest(manifest).build();
+        var plugin = Plugin.Builder.ofManifest(manifest).build();
         var input = "Benjamin";
         var result = new String(plugin.call("greet", input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         assertEquals("Hello, Benjamin!", result);
@@ -24,7 +23,7 @@ public class PluginTest
                         .fromUrl("https://github.com/extism/plugins/releases/download/v1.1.0/greet.wasm")
                         .withOptions(new Manifest.Options().withAoT())
                         .build();
-        var plugin = Plugin.ofManifest(manifest).build();
+        var plugin = Plugin.Builder.ofManifest(manifest).build();
         var input = "Benjamin";
         var result = new String(plugin.call("greet", input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         assertEquals("Hello, Benjamin!", result);


### PR DESCRIPTION
Some initial refactoring with the goal of cleaning up the surface. Still WIP, so draft for now, but pushing for early feedback. 

Essentially, I compared this to the other SDKs rather than just extism/java-sdk; especially I took _some_ inspiration from the C# version; however C# supports named parameters, and I figured that Builders will scale better as the number of constructor parameters grows (e.g. option values); so instead of creating multiple constructors, we prefer one constructor and a builder with named, optional flags.

Plan is to port tests from the java-sdk and align to chicory `main`, where the Module API has slightly changed (due to https://github.com/dylibso/chicory/pull/460)

