### PR TITLE
Ensure extism-runtime.wasm is bundled when using Native Image

### DIFF
--- a/src/main/resources/META-INF/native-image/org.extism/chicory-sdk/resource-config.json
+++ b/src/main/resources/META-INF/native-image/org.extism/chicory-sdk/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {
+      "pattern": "extism-runtime\\.wasm$"
+    }
+  ]
+}


### PR DESCRIPTION
This config file is picked up automatically by `native-image` so that the resulting executable always contains `extism-runtime.wasm`.

TODO: add test case for CI, but we can do that later.

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
