### PR TITLE
feat: expose wasi options in the manifest + add CompiledPlugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+    <jimfs.version>1.3.0</jimfs.version>
   </properties>
 
   <dependencies>
@@ -95,6 +96,13 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.jimfs</groupId>
+      <artifactId>jimfs</artifactId>
+      <version>${jimfs.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <profiles>

--- a/src/main/java/org/extism/chicory/sdk/CachedAotMachineFactory.java
+++ b/src/main/java/org/extism/chicory/sdk/CachedAotMachineFactory.java
@@ -13,7 +13,9 @@ class CachedAotMachineFactory implements Function<Instance, Machine> {
     private final Map<WasmModule, AotMachineFactory> factories = new HashMap<>();
 
     public CachedAotMachineFactory compile(WasmModule wasmModule) {
-        factories.put(wasmModule, new AotMachineFactory(wasmModule));
+        if (!factories.containsKey(wasmModule)) {
+            factories.put(wasmModule, new AotMachineFactory(wasmModule));
+        }
         return this;
     }
 

--- a/src/main/java/org/extism/chicory/sdk/CachedAotMachineFactory.java
+++ b/src/main/java/org/extism/chicory/sdk/CachedAotMachineFactory.java
@@ -1,0 +1,27 @@
+package org.extism.chicory.sdk;
+
+import com.dylibso.chicory.experimental.aot.AotMachineFactory;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.runtime.Machine;
+import com.dylibso.chicory.wasm.WasmModule;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+class CachedAotMachineFactory implements Function<Instance, Machine> {
+    private final Map<WasmModule, AotMachineFactory> factories = new HashMap<>();
+
+    public CachedAotMachineFactory compile(WasmModule wasmModule) {
+        factories.put(wasmModule, new AotMachineFactory(wasmModule));
+        return this;
+    }
+
+    public Machine apply(Instance instance) {
+        if (!factories.containsKey(instance.module())) {
+            throw new IllegalArgumentException("Instance module is not cached");
+        }
+        var factory = factories.get(instance.module());
+        return factory.apply(instance);
+    }
+}

--- a/src/main/java/org/extism/chicory/sdk/ChicoryModule.java
+++ b/src/main/java/org/extism/chicory/sdk/ChicoryModule.java
@@ -29,13 +29,13 @@ class ChicoryModule {
         }
     }
 
-    static Instance.Builder instanceWithOptions(Instance.Builder m, Manifest.Options opts) {
+    static Instance.Builder instanceWithOptions(Instance.Builder m, Manifest.Options opts, CachedAotMachineFactory aotMachineFactory) {
         if (opts == null) {
             return m;
         }
         // This feature is not compatibly with the native-image builder.
         if (opts.aot && !IS_NATIVE_IMAGE_AOT) {
-            m.withMachineFactory(AotMachine::new);
+            m.withMachineFactory(aotMachineFactory);
         }
         if (!opts.validationFlags.isEmpty()) {
             throw new UnsupportedOperationException("Validation flags are not supported yet");

--- a/src/main/java/org/extism/chicory/sdk/CompiledPlugin.java
+++ b/src/main/java/org/extism/chicory/sdk/CompiledPlugin.java
@@ -1,0 +1,17 @@
+package org.extism.chicory.sdk;
+
+/**
+ * A plugin that has been already processed, but not yet instantiated.
+ * Every instance is independent and shares no state.
+ */
+public class CompiledPlugin {
+    private final Linker linker;
+
+    CompiledPlugin(Linker linker) {
+        this.linker = linker;
+    }
+
+    public Plugin instantiate() {
+        return linker.link();
+    }
+}

--- a/src/main/java/org/extism/chicory/sdk/Linker.java
+++ b/src/main/java/org/extism/chicory/sdk/Linker.java
@@ -28,7 +28,14 @@ class Linker {
         this.logger = logger;
     }
 
-    public Plugin link() {
+    // Note: this is really doing nothing besides wrapping
+    // the linker, because, at this time, we do not really have a concept
+    // of CompiledPlugin in Chicory.
+    CompiledPlugin compile() {
+        return new CompiledPlugin(this);
+    }
+
+    Plugin link() {
 
         var dg = new DependencyGraph(logger);
         dg.setOptions(manifest.options);

--- a/src/main/java/org/extism/chicory/sdk/Linker.java
+++ b/src/main/java/org/extism/chicory/sdk/Linker.java
@@ -47,12 +47,11 @@ class Linker {
         dg.registerFunctions(hostEnv.toHostFunctions());
 
         // Register the WASI host functions.
-        dg.registerFunctions(new WasiPreview1(logger,
-                WasiOptions.builder()
-                        .withArguments(List.of("main"))
-                        .withStdout(System.out)
-                        .withStderr(System.err)
-                        .build()).toHostFunctions());
+        dg.registerFunctions(new WasiPreview1(
+                logger,
+                manifest.options == null ?
+                        Manifest.Options.defaultWasiOptions() :
+                        manifest.options.wasiOptions).toHostFunctions());
 
         // Register the user-provided host functions.
         dg.registerFunctions(Arrays.stream(this.hostFunctions)
@@ -64,7 +63,7 @@ class Linker {
 
         // Instantiate the main module, and, recursively, all of its dependencies.
         Instance main = dg.instantiate();
-    
+
         Plugin p = new Plugin(main, hostEnv);
         CurrentPlugin curr = new CurrentPlugin(p);
 

--- a/src/main/java/org/extism/chicory/sdk/Linker.java
+++ b/src/main/java/org/extism/chicory/sdk/Linker.java
@@ -37,17 +37,20 @@ class Linker {
 
         Map<String, String> config;
         WasiOptions wasiOptions;
+        CachedAotMachineFactory aotMachineFactory;
         if (manifest.options == null) {
             config = Map.of();
             wasiOptions = null;
+            aotMachineFactory = null;
         } else {
             dg.setOptions(manifest.options);
             config = manifest.options.config;
             wasiOptions = manifest.options.wasiOptions;
+            aotMachineFactory = manifest.options.aot? new CachedAotMachineFactory() : null;
         }
 
         // Register the HostEnv exports.
-        var hostEnv = new HostEnv(new Kernel(), config, logger);
+        var hostEnv = new HostEnv(new Kernel(aotMachineFactory), config, logger);
         dg.registerFunctions(hostEnv.toHostFunctions());
 
         // Register the WASI host functions.
@@ -56,7 +59,6 @@ class Linker {
                     new WasiPreview1(
                             logger, wasiOptions).toHostFunctions());
         }
-
 
         // Register the user-provided host functions.
         dg.registerFunctions(Arrays.stream(this.hostFunctions)

--- a/src/main/java/org/extism/chicory/sdk/Linker.java
+++ b/src/main/java/org/extism/chicory/sdk/Linker.java
@@ -28,9 +28,6 @@ class Linker {
         this.logger = logger;
     }
 
-    // Note: this is really doing nothing besides wrapping
-    // the linker, because, at this time, we do not really have a concept
-    // of CompiledPlugin in Chicory.
     CompiledPlugin compile() {
         return new CompiledPlugin(this);
     }

--- a/src/main/java/org/extism/chicory/sdk/Manifest.java
+++ b/src/main/java/org/extism/chicory/sdk/Manifest.java
@@ -16,7 +16,7 @@ public class Manifest {
         boolean aot;
         EnumSet<Validation> validationFlags = EnumSet.noneOf(Validation.class);
         Map<String, String> config;
-        WasiOptions wasiOptions = defaultWasiOptions();
+        WasiOptions wasiOptions;
 
         public Options withAoT() {
             this.aot = true;
@@ -36,14 +36,6 @@ public class Manifest {
         public Options withWasi(WasiOptions wasiOptions) {
             this.wasiOptions = wasiOptions;
             return this;
-        }
-
-        static WasiOptions defaultWasiOptions() {
-            return WasiOptions.builder()
-                    .withArguments(List.of("main"))
-                    .withStdout(System.out)
-                    .withStderr(System.err)
-                    .build();
         }
 
     }

--- a/src/main/java/org/extism/chicory/sdk/Manifest.java
+++ b/src/main/java/org/extism/chicory/sdk/Manifest.java
@@ -1,5 +1,7 @@
 package org.extism.chicory.sdk;
 
+import com.dylibso.chicory.wasi.WasiOptions;
+
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +16,7 @@ public class Manifest {
         boolean aot;
         EnumSet<Validation> validationFlags = EnumSet.noneOf(Validation.class);
         Map<String, String> config;
+        WasiOptions wasiOptions = null;
 
         public Options withAoT() {
             this.aot = true;
@@ -27,6 +30,11 @@ public class Manifest {
 
         public Options withValidation(Validation... vs) {
             this.validationFlags.addAll(List.of(vs));
+            return this;
+        }
+
+        public Options withWasiOptions(WasiOptions wasiOptions) {
+            this.wasiOptions = wasiOptions;
             return this;
         }
     }

--- a/src/main/java/org/extism/chicory/sdk/Manifest.java
+++ b/src/main/java/org/extism/chicory/sdk/Manifest.java
@@ -16,7 +16,7 @@ public class Manifest {
         boolean aot;
         EnumSet<Validation> validationFlags = EnumSet.noneOf(Validation.class);
         Map<String, String> config;
-        WasiOptions wasiOptions = null;
+        WasiOptions wasiOptions = defaultWasiOptions();
 
         public Options withAoT() {
             this.aot = true;
@@ -33,10 +33,19 @@ public class Manifest {
             return this;
         }
 
-        public Options withWasiOptions(WasiOptions wasiOptions) {
+        public Options withWasi(WasiOptions wasiOptions) {
             this.wasiOptions = wasiOptions;
             return this;
         }
+
+        static WasiOptions defaultWasiOptions() {
+            return WasiOptions.builder()
+                    .withArguments(List.of("main"))
+                    .withStdout(System.out)
+                    .withStderr(System.err)
+                    .build();
+        }
+
     }
 
 

--- a/src/main/java/org/extism/chicory/sdk/Plugin.java
+++ b/src/main/java/org/extism/chicory/sdk/Plugin.java
@@ -38,10 +38,15 @@ public class Plugin {
             return this;
         }
 
-        public Plugin build() {
+        public CompiledPlugin compile() {
             var logger = this.logger == null ? new SystemLogger() : this.logger;
             Linker linker = new Linker(this.manifest, this.hostFunctions, logger);
-            return linker.link();
+            return linker.compile();
+        }
+
+        // Synonym for Plugin.ofManifest(Manifest).compile().instantiate();
+        public Plugin build() {
+            return compile().instantiate();
         }
     }
 

--- a/src/test/java/org/extism/chicory/sdk/PluginTest.java
+++ b/src/test/java/org/extism/chicory/sdk/PluginTest.java
@@ -120,4 +120,6 @@ public class PluginTest extends TestCase {
         assertEquals("{\"count\":3,\"total\":3,\"vowels\":\"aeiouAEIOU\"}", result);
     }
 
+
+
 }

--- a/src/test/java/org/extism/chicory/sdk/PluginTest.java
+++ b/src/test/java/org/extism/chicory/sdk/PluginTest.java
@@ -29,7 +29,7 @@ public class PluginTest extends TestCase {
     public void testGreetAoT() {
         var url = "https://github.com/extism/plugins/releases/download/v1.1.1/greet.wasm";
         var wasm = ManifestWasm.fromUrl(url).build();
-        var manifest = Manifest.ofWasms(wasm).build();
+        var manifest = Manifest.ofWasms(wasm).withOptions(new Manifest.Options().withAoT()).build();
         var plugin = Plugin.ofManifest(manifest).build();
         var input = "Benjamin";
         var result = new String(plugin.call("greet", input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);


### PR DESCRIPTION
- WASI was simply _always_ instantiated, with no way to configure it further. Now it is disabled by default, and it is instantiated only when WASI options are provided.
- We also provide an implementation of `CompiledPlugin` that keeps a cache of pre-processed modules (pre-compiled if aot==true) and allows instantiation all at once, several times.