### PR TITLE
http: add json+jackson support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <jimfs.version>1.3.0</jimfs.version>
     <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
     <jakarta.json.version>1.1.7</jakarta.json.version>
+    <jackson-core.version>2.18.2</jackson-core.version>
   </properties>
 
   <dependencies>
@@ -103,6 +104,12 @@
       <artifactId>jimfs</artifactId>
       <version>${jimfs.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson-core.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>jakarta.json</groupId>

--- a/src/main/java/org/extism/sdk/chicory/HttpConfig.java
+++ b/src/main/java/org/extism/sdk/chicory/HttpConfig.java
@@ -1,12 +1,16 @@
 package org.extism.sdk.chicory;
 
+import java.util.Objects;
+
 public class HttpConfig {
     /**
      * Use {@link JdkHttpClientAdapter} for the HTTP client adapter.
      * Recommended on recent Java versions.
      */
     public static HttpConfig defaultConfig() {
-        return new HttpConfig().withClientAdapter(new JdkHttpClientAdapter()).withJsonCodec(new JakartaJsonCodec());
+        return HttpConfig.builder()
+                .withClientAdapter(new JdkHttpClientAdapter())
+                .withJsonCodec(new JacksonJsonCodec()).build();
     }
 
     /**
@@ -14,19 +18,45 @@ public class HttpConfig {
      * Recommended for Android.
      */
     public static HttpConfig urlConnectionConfig() {
-        return new HttpConfig().withClientAdapter(new HttpUrlConnectionClientAdapter()).withJsonCodec(new JakartaJsonCodec());
+        return HttpConfig.builder()
+                .withClientAdapter(new HttpUrlConnectionClientAdapter())
+                .withJsonCodec(new JakartaJsonCodec()).build();
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        HttpJsonCodec httpJsonCodec;
+        HttpClientAdapter httpClientAdapter;
+
+        private Builder() {}
+
+        public Builder withJsonCodec(HttpJsonCodec httpJsonCodec) {
+            this.httpJsonCodec = httpJsonCodec;
+            return this;
+        }
+
+        public Builder withClientAdapter(HttpClientAdapter httpClientAdapter) {
+            this.httpClientAdapter = httpClientAdapter;
+            return this;
+        }
+
+        public HttpConfig build() {
+            Objects.requireNonNull(httpJsonCodec, "httpJsonCodec is required");
+            Objects.requireNonNull(httpClientAdapter, "httpClientAdapter is required");
+            return new HttpConfig(httpJsonCodec, httpClientAdapter);
+        }
+    }
+
 
     HttpJsonCodec httpJsonCodec;
     HttpClientAdapter httpClientAdapter;
 
-    public HttpConfig withJsonCodec(HttpJsonCodec httpJsonCodec) {
+    public HttpConfig(HttpJsonCodec httpJsonCodec, HttpClientAdapter httpClientAdapter) {
         this.httpJsonCodec = httpJsonCodec;
-        return this;
+        this.httpClientAdapter = httpClientAdapter;
     }
 
-    public HttpConfig withClientAdapter(HttpClientAdapter httpClientAdapter) {
-        this.httpClientAdapter = httpClientAdapter;
-        return this;
-    }
 }

--- a/src/main/java/org/extism/sdk/chicory/JacksonJsonCodec.java
+++ b/src/main/java/org/extism/sdk/chicory/JacksonJsonCodec.java
@@ -1,0 +1,70 @@
+package org.extism.sdk.chicory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JacksonJsonCodec implements HttpJsonCodec {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public RequestMetadata decodeMetadata(byte[] data) {
+
+        JsonNode request = null;
+        try {
+            request = objectMapper.readTree(data);
+        } catch (IOException e) {
+            throw new ExtismException(e);
+        }
+
+        var method = request.get("method").asText();
+        var uri = URI.create(request.get("url").asText());
+        var headers = request.get("headers");
+
+        Map<String, String> headersMap = new HashMap<>();
+        var fields = headers.fields();
+        while (fields.hasNext()) {
+            var entry = fields.next();
+            headersMap.put(entry.getKey(), entry.getValue().asText());
+        }
+
+        return new RequestMetadata() {
+            @Override
+            public String method() {
+                return method;
+            }
+
+            @Override
+            public URI uri() {
+                return uri;
+            }
+
+            @Override
+            public Map<String, String> headers() {
+                return headersMap;
+            }
+        };
+    }
+
+    public byte[] encodeHeaders(Map<String, List<String>> headers) {
+        // FIXME duplicated headers are effectively overwriting duplicate values!
+        var objectNode = objectMapper.createObjectNode();
+        for (var entry : headers.entrySet()) {
+            for (var v : entry.getValue()) {
+                objectNode.put(entry.getKey(), v);
+            }
+        }
+        try {
+            return objectMapper.writeValueAsBytes(objectNode);
+        } catch (JsonProcessingException e) {
+            throw new ExtismException(e);
+        }
+    }
+}

--- a/src/test/java/org/extism/sdk/chicory/HostEnvTest.java
+++ b/src/test/java/org/extism/sdk/chicory/HostEnvTest.java
@@ -11,7 +11,7 @@ public class HostEnvTest extends TestCase {
         var logger = new SystemLogger();
 
         var config = Map.of("key", "value");
-        var hostEnv = new HostEnv(new Kernel(), config, new String[0], new HttpConfig(), logger);
+        var hostEnv = new HostEnv(new Kernel(), config, new String[0], HttpConfig.defaultConfig(), logger);
 
         assertEquals(hostEnv.config().get("key"), "value");
 

--- a/src/test/java/org/extism/sdk/chicory/HttpTest.java
+++ b/src/test/java/org/extism/sdk/chicory/HttpTest.java
@@ -15,13 +15,11 @@ public class HttpTest extends TestCase {
 
     public void testNoAllowedHosts() {
         noAllowedHosts(HttpConfig.defaultConfig());
-        noAllowedHosts(HttpConfig.defaultConfig().withJsonCodec(new JacksonJsonCodec()));
         noAllowedHosts(HttpConfig.urlConnectionConfig());
     }
 
     public void testAllowSingleHost() {
         allowSingleHost(HttpConfig.defaultConfig());
-        allowSingleHost(HttpConfig.defaultConfig().withJsonCodec(new JacksonJsonCodec()));
         allowSingleHost(HttpConfig.urlConnectionConfig());
     }
 
@@ -32,13 +30,11 @@ public class HttpTest extends TestCase {
 
     public void testAllowMultiHostPattern() {
         allowMultiHostPattern(HttpConfig.defaultConfig());
-        allowMultiHostPattern(HttpConfig.defaultConfig().withJsonCodec(new JacksonJsonCodec()));
         allowMultiHostPattern(HttpConfig.urlConnectionConfig());
     }
 
     public void testAllowAnyHost() {
         allowAnyHost(HttpConfig.defaultConfig());
-        allowAnyHost(HttpConfig.defaultConfig().withJsonCodec(new JacksonJsonCodec()));
         allowAnyHost(HttpConfig.urlConnectionConfig());
     }
 

--- a/src/test/java/org/extism/sdk/chicory/HttpTest.java
+++ b/src/test/java/org/extism/sdk/chicory/HttpTest.java
@@ -15,11 +15,13 @@ public class HttpTest extends TestCase {
 
     public void testNoAllowedHosts() {
         noAllowedHosts(HttpConfig.defaultConfig());
+        noAllowedHosts(HttpConfig.defaultConfig().withJsonCodec(new JacksonJsonCodec()));
         noAllowedHosts(HttpConfig.urlConnectionConfig());
     }
 
     public void testAllowSingleHost() {
         allowSingleHost(HttpConfig.defaultConfig());
+        allowSingleHost(HttpConfig.defaultConfig().withJsonCodec(new JacksonJsonCodec()));
         allowSingleHost(HttpConfig.urlConnectionConfig());
     }
 
@@ -30,11 +32,13 @@ public class HttpTest extends TestCase {
 
     public void testAllowMultiHostPattern() {
         allowMultiHostPattern(HttpConfig.defaultConfig());
+        allowMultiHostPattern(HttpConfig.defaultConfig().withJsonCodec(new JacksonJsonCodec()));
         allowMultiHostPattern(HttpConfig.urlConnectionConfig());
     }
 
     public void testAllowAnyHost() {
         allowAnyHost(HttpConfig.defaultConfig());
+        allowAnyHost(HttpConfig.defaultConfig().withJsonCodec(new JacksonJsonCodec()));
         allowAnyHost(HttpConfig.urlConnectionConfig());
     }
 


### PR DESCRIPTION
- add another JSON library, Jacksons, basically the de-facto standard...
- switch to it
- expose an HttpConfig.Builder instead of a direct constructor