### PR TITLE
feat: config provider

### DIFF
--- a/src/main/java/org/extism/sdk/chicory/ConfigProvider.java
+++ b/src/main/java/org/extism/sdk/chicory/ConfigProvider.java
@@ -3,7 +3,7 @@ package org.extism.sdk.chicory;
 import java.util.Map;
 
 public interface ConfigProvider {
-    static ConfigProvider Empty() {
+    static ConfigProvider empty() {
         return key -> null;
     }
 

--- a/src/main/java/org/extism/sdk/chicory/ConfigProvider.java
+++ b/src/main/java/org/extism/sdk/chicory/ConfigProvider.java
@@ -1,0 +1,15 @@
+package org.extism.sdk.chicory;
+
+import java.util.Map;
+
+public interface ConfigProvider {
+    static ConfigProvider Empty() {
+        return key -> null;
+    }
+
+    static ConfigProvider ofMap(Map<String, String> map) {
+        return map::get;
+    }
+
+    String get(String key);
+}

--- a/src/main/java/org/extism/sdk/chicory/HostEnv.java
+++ b/src/main/java/org/extism/sdk/chicory/HostEnv.java
@@ -22,7 +22,7 @@ public class HostEnv {
     private final Config config;
     private final Http http;
 
-    public HostEnv(Kernel kernel, Map<String, String> config, String[] allowedHosts, HttpConfig httpConfig, Logger logger) {
+    public HostEnv(Kernel kernel, ConfigProvider config, String[] allowedHosts, HttpConfig httpConfig, Logger logger) {
         this.kernel = kernel;
         this.memory = new Memory();
         this.logger = logger;
@@ -240,9 +240,9 @@ public class HostEnv {
 
     public class Config {
 
-        private final Map<String, String> config;
+        private final ConfigProvider config;
 
-        private Config(Map<String, String> config) {
+        private Config(ConfigProvider config) {
             this.config = config;
         }
 

--- a/src/main/java/org/extism/sdk/chicory/Linker.java
+++ b/src/main/java/org/extism/sdk/chicory/Linker.java
@@ -34,7 +34,7 @@ class Linker {
     Plugin link() {
         var dg = new DependencyGraph(logger);
 
-        Map<String, String> config;
+        ConfigProvider config;
         String[] allowedHosts;
         WasiOptions wasiOptions;
         CachedAotMachineFactory aotMachineFactory;

--- a/src/main/java/org/extism/sdk/chicory/Manifest.java
+++ b/src/main/java/org/extism/sdk/chicory/Manifest.java
@@ -15,7 +15,7 @@ public class Manifest {
     public static class Options {
         boolean aot = false;
         EnumSet<Validation> validationFlags = EnumSet.noneOf(Validation.class);
-        Map<String, String> config = Map.of();
+        ConfigProvider config = ConfigProvider.Empty();
         WasiOptions wasiOptions = WasiOptions.builder().build();
         String[] allowedHosts = new String[0];
         HttpConfig httpConfig = HttpConfig.defaultConfig();
@@ -30,9 +30,14 @@ public class Manifest {
         }
 
         public Options withConfig(Map<String, String> config) {
+            return withConfigProvider(ConfigProvider.ofMap(config));
+        }
+
+        public Options withConfigProvider(ConfigProvider config) {
             this.config = config;
             return this;
         }
+
 
         public Options withValidation(Validation... vs) {
             this.validationFlags.addAll(List.of(vs));

--- a/src/main/java/org/extism/sdk/chicory/Manifest.java
+++ b/src/main/java/org/extism/sdk/chicory/Manifest.java
@@ -15,7 +15,7 @@ public class Manifest {
     public static class Options {
         boolean aot = false;
         EnumSet<Validation> validationFlags = EnumSet.noneOf(Validation.class);
-        ConfigProvider config = ConfigProvider.Empty();
+        ConfigProvider config = ConfigProvider.empty();
         WasiOptions wasiOptions = WasiOptions.builder().build();
         String[] allowedHosts = new String[0];
         HttpConfig httpConfig = HttpConfig.defaultConfig();

--- a/src/test/java/org/extism/sdk/chicory/HostEnvTest.java
+++ b/src/test/java/org/extism/sdk/chicory/HostEnvTest.java
@@ -4,6 +4,7 @@ import com.dylibso.chicory.log.SystemLogger;
 import junit.framework.TestCase;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 
 public class HostEnvTest extends TestCase {
@@ -11,7 +12,7 @@ public class HostEnvTest extends TestCase {
         var logger = new SystemLogger();
 
         var config = Map.of("key", "value");
-        var hostEnv = new HostEnv(new Kernel(), config, new String[0], HttpConfig.defaultConfig(), logger);
+        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.ofMap(config), new String[0], HttpConfig.defaultConfig(), logger);
 
         assertEquals(hostEnv.config().get("key"), "value");
 

--- a/src/test/java/org/extism/sdk/chicory/HttpTest.java
+++ b/src/test/java/org/extism/sdk/chicory/HttpTest.java
@@ -18,7 +18,7 @@ public class HttpTest extends TestCase {
         var logger = new SystemLogger();
 
         var anyHost = new String[]{"*.httpbin.org"};
-        var hostEnv = new HostEnv(new Kernel(), Map.of(), anyHost, httpConfig, logger);
+        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.empty(), anyHost, httpConfig, logger);
 
         try {
             byte[] response = hostEnv.http().request(
@@ -61,7 +61,7 @@ public class HttpTest extends TestCase {
         var logger = new SystemLogger();
 
         var noAllowedHosts = new String[0];
-        var hostEnv = new HostEnv(new Kernel(), Map.of(), noAllowedHosts, httpConfig, logger);
+        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.empty(), noAllowedHosts, httpConfig, logger);
 
         try {
             hostEnv.http().request(
@@ -79,7 +79,7 @@ public class HttpTest extends TestCase {
         var logger = new SystemLogger();
 
         var anyHost = new String[]{"httpbin.org"};
-        var hostEnv = new HostEnv(new Kernel(), Map.of(), anyHost, httpConfig, logger);
+        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.empty(), anyHost, httpConfig, logger);
 
         byte[] response = hostEnv.http().request(
                 "GET",
@@ -114,7 +114,7 @@ public class HttpTest extends TestCase {
         var logger = new SystemLogger();
 
         var anyHost = new String[]{"*.httpbin.org"};
-        var hostEnv = new HostEnv(new Kernel(), Map.of(), anyHost, httpConfig, logger);
+        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.empty(), anyHost, httpConfig, logger);
 
         byte[] response = hostEnv.http().request(
                 "GET",
@@ -142,7 +142,7 @@ public class HttpTest extends TestCase {
         var logger = new SystemLogger();
 
         var anyHost = new String[]{"*.httpbin.org", "httpbin.org"};
-        var hostEnv = new HostEnv(new Kernel(), Map.of(), anyHost, httpConfig, logger);
+        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.empty(), anyHost, httpConfig, logger);
 
         byte[] response = hostEnv.http().request(
                 "GET",
@@ -167,7 +167,7 @@ public class HttpTest extends TestCase {
         var logger = new SystemLogger();
 
         var anyHost = new String[]{"*"};
-        var hostEnv = new HostEnv(new Kernel(), Map.of(), anyHost, httpConfig, logger);
+        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.empty(), anyHost, httpConfig, logger);
 
         byte[] response = hostEnv.http().request(
                 "GET",


### PR DESCRIPTION
Config is now wrapped by a `ConfigProvider` the main goal is to shield the SDK from the implementation detail of Config being generally a Map, so that at config-time it is possible to supply a dynamic config provider.

The dynamic config provider could e.g. mutate Config keys or dynamically supply different values using custom logic. This will be useful in https://github.com/dylibso/mcpx4j/pull/5 to allow supplying updated tokens without restarting the servlet.