### PR TITLE
fix: call reset before new input

### DIFF
--- a/src/main/java/org/extism/sdk/chicory/Kernel.java
+++ b/src/main/java/org/extism/sdk/chicory/Kernel.java
@@ -72,6 +72,7 @@ public class Kernel {
     }
 
     public void setInput(byte[] input) {
+        reset.apply();
         var ptr = alloc.apply(input.length)[0];
         instanceMemory.write((int) ptr, input);
         inputSet.apply(ptr, input.length);


### PR DESCRIPTION
Fixes https://github.com/extism/chicory-sdk/issues/37, see the issue for more context. 