### PR TITLE
fix: ensure Memory methods are public

### DIFF
--- a/src/main/java/org/extism/sdk/chicory/HostEnv.java
+++ b/src/main/java/org/extism/sdk/chicory/HostEnv.java
@@ -93,16 +93,16 @@ public class HostEnv {
             return kernel.alloc.apply(size)[0];
         }
 
-        byte[] readBytes(long offset) {
+        public byte[] readBytes(long offset) {
             long length = length(offset);
             return memory().readBytes((int) offset, (int) length);
         }
 
-        String readString(long offset) {
+        public String readString(long offset) {
             return new String(readBytes(offset), StandardCharsets.UTF_8);
         }
 
-        long writeBytes(byte[] bytes) {
+        public long writeBytes(byte[] bytes) {
             long ptr = alloc(bytes.length);
             memory().write((int) ptr, bytes);
             return ptr;

--- a/src/test/java/org/extism/sdk/chicory/e2e/PluginTest.java
+++ b/src/test/java/org/extism/sdk/chicory/e2e/PluginTest.java
@@ -1,9 +1,15 @@
-package org.extism.sdk.chicory;
+package org.extism.sdk.chicory.e2e;
 
 import com.dylibso.chicory.wasi.WasiOptions;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import junit.framework.TestCase;
+import org.extism.sdk.chicory.ExtismFunction;
+import org.extism.sdk.chicory.ExtismHostFunction;
+import org.extism.sdk.chicory.ExtismValType;
+import org.extism.sdk.chicory.Manifest;
+import org.extism.sdk.chicory.ManifestWasm;
+import org.extism.sdk.chicory.Plugin;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
fixes #46 

Move the `PluginTest` class to `e2e` subpackage to ensure that we don't call non-public methods inadvertently.