### PR TITLE
fix: do not release http integration tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Release to Maven Central
         run: |
-          mvn --batch-mode --no-transfer-progress -Prelease clean verify deploy -X
+          mvn --batch-mode --no-transfer-progress -Drelease clean verify deploy -X
         env:
           MAVEN_USERNAME: ${{ secrets.JRELEASER_NEXUS2_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_PASSWORD }}

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -11,15 +11,44 @@
 
     <artifactId>http</artifactId>
     <packaging>pom</packaging>
-    <modules>
-        <module>json-jackson</module>
-        <module>json-jakarta</module>
-        <module>api</module>
-        <module>integration-tests</module>
-        <module>client-javanet</module>
-        <module>client-urlconnection</module>
-        <module>config-generic</module>
-        <module>config-android</module>
-    </modules>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!release</name>
+                </property>
+            </activation>
+            <modules>
+                <module>json-jackson</module>
+                <module>json-jakarta</module>
+                <module>api</module>
+                <module>integration-tests</module>
+                <module>client-javanet</module>
+                <module>client-urlconnection</module>
+                <module>config-generic</module>
+                <module>config-android</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
+            <modules>
+                <module>json-jackson</module>
+                <module>json-jakarta</module>
+                <module>api</module>
+                <module>client-javanet</module>
+                <module>client-urlconnection</module>
+                <module>config-generic</module>
+                <module>config-android</module>
+            </modules>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
   <profiles>
     <profile>
       <id>release</id>
+      <activation>
+        <property>
+          <name>release</name>
+        </property>
+      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
skip the http/integration-test module (empty otherwise)

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
