### PR TITLE
feat: configurable http response headers

### DIFF
--- a/core/src/main/java/org/extism/sdk/chicory/Linker.java
+++ b/core/src/main/java/org/extism/sdk/chicory/Linker.java
@@ -41,10 +41,12 @@ class Linker {
         WasiOptions wasiOptions;
         Function<Instance, Machine> machineFactory = null;
         HttpConfig httpConfig;
+        boolean enableHttpResponseHeaders;
         Manifest.Options options = manifest.options;
         dg.setOptions(options);
         config = options.config;
         allowedHosts = options.allowedHosts;
+        enableHttpResponseHeaders = options.enableHttpResponseHeaders;
         wasiOptions = options.wasiOptions;
         if (options.aot && options.machineFactory == null) {
             machineFactory = new CachedAotMachineFactory();
@@ -55,7 +57,7 @@ class Linker {
         httpConfig = options.httpConfig;
 
         // Register the HostEnv exports.
-        var hostEnv = new HostEnv(new Kernel(machineFactory), config, allowedHosts, httpConfig, logger);
+        var hostEnv = new HostEnv(new Kernel(machineFactory), config, allowedHosts, enableHttpResponseHeaders, httpConfig, logger);
         dg.registerFunctions(hostEnv.toHostFunctions());
 
         // Register the WASI host functions.

--- a/core/src/main/java/org/extism/sdk/chicory/Manifest.java
+++ b/core/src/main/java/org/extism/sdk/chicory/Manifest.java
@@ -24,6 +24,7 @@ public class Manifest {
         ConfigProvider config = ConfigProvider.empty();
         WasiOptions wasiOptions = WasiOptions.builder().build();
         String[] allowedHosts = new String[0];
+        public boolean enableHttpResponseHeaders;
         HttpConfig httpConfig = null;
         MemoryLimits memoryLimits = null;
 
@@ -69,6 +70,11 @@ public class Manifest {
 
         public Options withHttpConfig(HttpConfig httpConfig) {
             this.httpConfig = httpConfig;
+            return this;
+        }
+
+        public Options withHttpResponseHeaders(boolean enabled) {
+            this.enableHttpResponseHeaders = enabled;
             return this;
         }
 

--- a/core/src/test/java/org/extism/sdk/chicory/HostEnvTest.java
+++ b/core/src/test/java/org/extism/sdk/chicory/HostEnvTest.java
@@ -12,7 +12,7 @@ public class HostEnvTest extends TestCase {
         var logger = new SystemLogger();
 
         var config = Map.of("key", "value");
-        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.ofMap(config), new String[0], null, logger);
+        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.ofMap(config), new String[0], false, null, logger);
 
         assertEquals(hostEnv.config().get("key"), "value");
 
@@ -31,7 +31,7 @@ public class HostEnvTest extends TestCase {
         var logger = new SystemLogger();
 
         var config = Map.of("key", "value");
-        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.ofMap(config), new String[0], null, logger);
+        var hostEnv = new HostEnv(new Kernel(), ConfigProvider.ofMap(config), new String[0], false, null, logger);
         try {
             hostEnv.http().request("POST", URI.create("https://www.example.com"), Map.of(), new byte[0]);
             fail("It should throw an ExtismConfigurationException");


### PR DESCRIPTION
Note: this is a breaking change; consistently with other extism sdks, the feature is now disabled by default and must be explicitly enabled on a per-plugin basis with: 

```
Manifest.ofWasms(wasm)
   .withOptions(new Manifest.Options().withHttpResponseHeaders(true))
   .build()
```

closes #63 
